### PR TITLE
Infinite canvas - render only visible

### DIFF
--- a/src/components/DraggableCards.tsx
+++ b/src/components/DraggableCards.tsx
@@ -247,7 +247,18 @@ const StudentCard = React.memo(
           top: `${offsets[1]}px`,
           backgroundImage: `url(${student.portfolio_icon.src})`,
         }}
-      ></div>
+      >
+        <VisibilitySensor partialVisibility={true} delayedCall={true}>
+          <div
+            style={{
+              width: `${cardSize[0] - 20}px`,
+              height: `${cardSize[1] - 20}px`,
+              left: `0px`,
+              top: `0px`,
+            }}
+          ></div>
+        </VisibilitySensor>
+      </div>
     );
   }
 );


### PR DESCRIPTION
Refactored Infinite Canvas/draggable cards in the following way:
    * Split DraggableCard into itself and a Smaller component that is only rendered when the cards to show have changed.  This is determined by the matrixX and matrixY, which only changes every x often, determined by the draggable screen current.
    * Element that is dragged is the wrapper element.  All child elements are placed in absolute position inside of that, and are just dragged with the wrapper element.
    * Only cards are rendered that are within x card positions of the current matrix x and y
    * StudentCards dont worry about visibility - they just are rendered if they are part of the viewable grid.
    * Wrapped functions in React.memo - which prevents them from being rendered unless their props change.
    * Split each state value into its own useState/useEffect so that each state value can be updated independently