### PR TITLE
Repeating cards

### DIFF
--- a/src/components/DraggableCards.tsx
+++ b/src/components/DraggableCards.tsx
@@ -6,7 +6,7 @@ import React, {
   useContext,
   useCallback,
 } from "react";
-import { IFilteredStudent } from "../types";
+import { IStudentSummary } from "../types";
 import { useSpring, animated } from "react-spring";
 import { useDrag } from "react-use-gesture";
 import {
@@ -23,7 +23,7 @@ import { clearMessageHub } from "./MessageHub";
 import CardsMatrix from "./CardsMatrix";
 
 interface IDraggableCardsProps {
-  filteredStudents: IFilteredStudent[];
+  studentsToShow: IStudentSummary[];
 }
 
 const smoother = new SmoothVector();
@@ -58,7 +58,7 @@ const getWindowSizeInCards = (windowSize: [number, number], cardSize: Vector) =>
     Math.ceil(windowSize[1] / cardSize[1]),
   ]);
 
-const DraggableCards = ({ filteredStudents }: IDraggableCardsProps) => {
+const DraggableCards = ({ studentsToShow }: IDraggableCardsProps) => {
   const { windowSize, navigatorPlatform } = useContext(Context);
   const [windowWidth, windowHeight] = windowSize;
   const [position, setSpring] = useSpring<Position>(() => ({
@@ -152,7 +152,7 @@ const DraggableCards = ({ filteredStudents }: IDraggableCardsProps) => {
     setMatrixEdges(getMatrixEdges(windowSizeInCards, matrixCenterXy));
   }, [...matrixCenterXy, windowSizeInCards]);
 
-  if (!filteredStudents) return null;
+  if (!studentsToShow) return null;
 
   return (
     <>
@@ -165,7 +165,7 @@ const DraggableCards = ({ filteredStudents }: IDraggableCardsProps) => {
         <animated.div style={{ ...position }}>
           <CardsMatrix
             {...{
-              filteredStudents,
+              studentsToShow,
               matrixEdges,
             }}
           />

--- a/src/components/Explore.tsx
+++ b/src/components/Explore.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 // import StudentCards from "./StudentCards";
-import { IStudentSummary, IFilteredStudent, TopicDict, ISearch } from "types";
+import { IStudentSummary, TopicDict, ISearch } from "types";
 import DraggableCards from "./DraggableCards";
 import { Container } from "react-bootstrap";
 import Footer from "./Footer/index";
@@ -25,11 +25,8 @@ interface IHomeProps {
 const updateFilteredStudents = (
   students: IStudentSummary[],
   filter: (student: IStudentSummary) => boolean
-): IFilteredStudent[] => {
-  return students.map((student) => ({
-    show: filter(student),
-    student,
-  }));
+): IStudentSummary[] => {
+  return students.filter(filter);
 };
 
 interface FilterOptions {
@@ -41,8 +38,8 @@ const noFilter = (student: IStudentSummary) => true;
 
 const Explore = ({ students }: IHomeProps) => {
   const [filteredStudents, setFilteredStudents] = useState<
-    IFilteredStudent[] | null
-  >(null);
+    IStudentSummary[] | undefined
+  >();
   const [searchText, setSearchText] = useState<string>("");
 
   const tagMatch = useRouteMatch<{ tag: string }>("/filter/category/:tag");
@@ -112,7 +109,7 @@ const Explore = ({ students }: IHomeProps) => {
   return (
     <Container fluid>
       <div className="row">
-        <DraggableCards filteredStudents={filteredStudents} />
+        <DraggableCards studentsToShow={filteredStudents} />
       </div>
       <Footer
         {...filterOptions}

--- a/src/components/Footer/Search.tsx
+++ b/src/components/Footer/Search.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { IFilteredStudent } from "types";
+import { IStudentSummary } from "types";
 import { FooterLeft, ScrollableFooterRight } from "./util";
 import { Nav, Form } from "react-bootstrap";
 import { Link } from "react-router-dom";
@@ -8,7 +8,7 @@ import { CloseBlack } from "components/Svg";
 interface SearchProps {
   text: string;
   textChanged: (search: string) => void;
-  searchResults: IFilteredStudent[];
+  searchResults: IStudentSummary[];
 }
 
 const SearchMain = ({ text, textChanged, searchResults }: SearchProps) => {
@@ -33,16 +33,13 @@ const SearchMain = ({ text, textChanged, searchResults }: SearchProps) => {
         </Nav.Item>
       </FooterLeft>
       <ScrollableFooterRight scrollableWidth={500}>
-        {searchResults.map(
-          ({ show, student }) =>
-            show && (
-              <Nav.Item key={student.student_id}>
-                <Link to={`/students/${student.student_id}`}>
-                  {student.student_name}
-                </Link>
-              </Nav.Item>
-            )
-        )}
+        {searchResults.map((student) => (
+          <Nav.Item key={student.student_id}>
+            <Link to={`/students/${student.student_id}`}>
+              {student.student_name}
+            </Link>
+          </Nav.Item>
+        ))}
       </ScrollableFooterRight>
     </>
   );

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { TopicDict, IFilteredStudent } from "types";
+import { TopicDict, IStudentSummary } from "types";
 import { Navbar, Nav } from "react-bootstrap";
 import { Route, Switch, Link } from "react-router-dom";
 import { SearchIcon, Random, Filter } from "components/Svg";
@@ -31,7 +31,7 @@ interface FooterProps {
   advisors?: TopicDict;
   searchText: string;
   searchTextChanged: (searchText: string) => void;
-  filteredStudents: IFilteredStudent[];
+  filteredStudents: IStudentSummary[];
 }
 
 const Footer = ({

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,14 +70,9 @@ export declare type IStudentFilter = (student: IStudentSummary) => boolean;
 
 type FilterStatus = "add" | "remove" | "nochange";
 
-export interface IFilteredStudent {
-  show: boolean;
-  student: IStudentSummary;
-}
-
 export interface ISearchResult {
   student_id: string;
   student_name: string;
 }
 
-export declare type ISearch = (search: string) => IFilteredStudent[];
+export declare type ISearch = (search: string) => IStudentSummary[];

--- a/src/util/search.ts
+++ b/src/util/search.ts
@@ -6,29 +6,13 @@ interface ISearchableStudent extends IStudentSummary {
 }
 
 export const buildSearch = (students: IStudentSummary[]): ISearch => {
-  const searchableStudent = students.map((student, index) => ({
-    ...student,
-    index,
-  }));
-
   const search = new JsSearch.Search("student_name");
   search.addIndex("student_name");
   search.addIndex("title");
 
-  search.addDocuments(searchableStudent);
+  search.addDocuments(students);
 
   return (searchString: string) => {
-    const searchResults = search.search(searchString) as ISearchableStudent[];
-
-    const filteredResults = students.map((student) => ({
-      student,
-      show: false,
-    }));
-
-    searchResults.forEach((result) => {
-      filteredResults[result.index].show = true;
-    });
-
-    return filteredResults;
+    return search.search(searchString) as IStudentSummary[];
   };
 };


### PR DESCRIPTION
This changes the behavior to have the home page projects repeat if there are less than 40 projects shown, to prevent it show projects appearing in different orders.

Some code changes:
* Simplified passing filtered students down to children by just passing an array of `IStudentSummary[]` as it was before.
* Changed `CardMatrix` to just contain the student itself, to simplify the code and make lookup easier.  Additionally `CardToShow` now just contains the student and not the student index.