### PR TITLE
Not transitioning cards

### DIFF
--- a/src/components/Explore/CardsMatrix.tsx
+++ b/src/components/Explore/CardsMatrix.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { multiplyElementWise, scaleVector, IMatrixEdges } from "util/vector";
 import { CardToShow, IStudentSummary, ICardSize } from "types";
 
-import { StudentCardWithTransition } from "../Shared/StudentCard";
+import { StudentCard } from "../Shared/StudentCard";
 
 const DEBUG = false;
 
@@ -99,13 +99,18 @@ const CardsMatrix = React.memo(
             [cardSize.widthWithMargin, cardSize.heightWithMargin]
           );
           return (
-            <StudentCardWithTransition
-              x={offsets[0]}
-              y={offsets[1]}
+            <div
               key={`${item.matrixX}_${item.matrixY}`}
-              skipAnimation={skipAnimation}
-              student={item.student}
-            />
+              style={{
+                position: "absolute",
+                width: cardSize.width,
+                height: cardSize.height,
+                left: `${offsets[0]}px`,
+                top: `${offsets[1]}px`,
+              }}
+            >
+              <StudentCard student={item.student} cardSize={cardSize} />
+            </div>
           );
         })}
       </>

--- a/src/components/Shared/StudentCard.tsx
+++ b/src/components/Shared/StudentCard.tsx
@@ -84,40 +84,42 @@ interface IStudentCardProps {
   cardSize: ICardSize;
 }
 
-const StudentCard = React.memo(({ student, cardSize }: IStudentCardProps) => {
-  const linkRef = useRef<null | HTMLAnchorElement | any>(null);
-  const [isDragging, setDragging] = useState<boolean>(false);
-  const onClick = (e: React.FormEvent<HTMLAnchorElement>): void => {
-    if (isDragging) e.preventDefault();
-  };
-  let clickStartXy = [0, 0];
-  const onMouseDown = (e: React.MouseEvent) => {
-    if (!linkRef.current) return;
-    clickStartXy = [e.clientX, e.clientY];
-  };
-  const onMouseUp = (e: React.MouseEvent) => {
-    if (!linkRef.current) return;
-    const dist = Math.hypot(
-      e.clientX - clickStartXy[0],
-      e.clientY - clickStartXy[1]
+export const StudentCard = React.memo(
+  ({ student, cardSize }: IStudentCardProps) => {
+    const linkRef = useRef<null | HTMLAnchorElement | any>(null);
+    const [isDragging, setDragging] = useState<boolean>(false);
+    const onClick = (e: React.FormEvent<HTMLAnchorElement>): void => {
+      if (isDragging) e.preventDefault();
+    };
+    let clickStartXy = [0, 0];
+    const onMouseDown = (e: React.MouseEvent) => {
+      if (!linkRef.current) return;
+      clickStartXy = [e.clientX, e.clientY];
+    };
+    const onMouseUp = (e: React.MouseEvent) => {
+      if (!linkRef.current) return;
+      const dist = Math.hypot(
+        e.clientX - clickStartXy[0],
+        e.clientY - clickStartXy[1]
+      );
+      if (dist > 10) setDragging(true);
+      else setDragging(false);
+    };
+    return (
+      <CardOuter width={cardSize.width} height={cardSize.height}>
+        <Link
+          to={`/students/${student.student_id}`}
+          ref={linkRef}
+          onMouseDown={onMouseDown}
+          onMouseUp={onMouseUp}
+          onClick={onClick}
+        >
+          <CardContent {...{ student, cardSize }} />
+        </Link>
+      </CardOuter>
     );
-    if (dist > 10) setDragging(true);
-    else setDragging(false);
-  };
-  return (
-    <CardOuter width={cardSize.width} height={cardSize.height}>
-      <Link
-        to={`/students/${student.student_id}`}
-        ref={linkRef}
-        onMouseDown={onMouseDown}
-        onMouseUp={onMouseUp}
-        onClick={onClick}
-      >
-        <CardContent {...{ student, cardSize }} />
-      </Link>
-    </CardOuter>
-  );
-});
+  }
+);
 
 const formatTag = (tagName: string) => he.decode(tagName.toUpperCase());
 


### PR DESCRIPTION
Performance improvement.  Getting rid of the transition makes the home page load faster, along with filtering/searching.

We should consider adding it back in, but as css animations for performance.