### PR TITLE
Optimize explore

### DIFF
--- a/src/components/Explore/CardsMatrix.tsx
+++ b/src/components/Explore/CardsMatrix.tsx
@@ -61,31 +61,26 @@ const CardsMatrix = React.memo(
   ({ studentsToShow, matrixEdges, cardSize }: ICardsProps) => {
     DEBUG && console.log("re-render CardsMatrix");
 
-    const [cardsToShow, setCardsToShow] = useState<CardToShow[] | null>(null);
+    const [{ cards, cardStudents }, setCardsAndStudents] = useState<{
+      cards: CardToShow[];
+      cardStudents: IStudentSummary[];
+    }>({ cards: [], cardStudents: [] });
 
     useEffect(() => {
       DEBUG && console.log("calling getCardsInMatrixToShow");
-      setCardsToShow(repeatCards(matrixEdges, cardSize));
+      const cards = repeatCards(matrixEdges, cardSize);
+
+      setCardsAndStudents({
+        cards,
+        cardStudents: studentsToShow
+          ? getStudentsForCards(cards, matrixEdges, studentsToShow)
+          : [],
+      });
     }, [matrixEdges, studentsToShow, cardSize]);
-
-    const [cardStudents, setCardStudents] = useState<IStudentSummary[]>([]);
-
-    useEffect(() => {
-      if (!studentsToShow || !cardsToShow) {
-        setCardStudents([]);
-        return;
-      }
-
-      setCardStudents(
-        getStudentsForCards(cardsToShow, matrixEdges, studentsToShow)
-      );
-    }, [matrixEdges, cardsToShow, studentsToShow]);
-
-    if (!cardsToShow) return null;
 
     return (
       <>
-        {cardsToShow.map(({ matrixX, matrixY, offset }, i) => (
+        {cards.map(({ matrixX, matrixY, offset }, i) => (
           <div
             key={`${matrixX}_${matrixY}`}
             style={{

--- a/src/components/Explore/CardsMatrix.tsx
+++ b/src/components/Explore/CardsMatrix.tsx
@@ -70,11 +70,13 @@ const CardsMatrix = React.memo(
       DEBUG && console.log("calling getCardsInMatrixToShow");
       const cards = repeatCards(matrixEdges, cardSize);
 
+      const studentsForCards = studentsToShow
+        ? getStudentsForCards(cards, matrixEdges, studentsToShow)
+        : [];
+
       setCardsAndStudents({
         cards,
-        cardStudents: studentsToShow
-          ? getStudentsForCards(cards, matrixEdges, studentsToShow)
-          : [],
+        cardStudents: studentsForCards,
       });
     }, [matrixEdges, studentsToShow, cardSize]);
 

--- a/src/components/Explore/DraggableCards.tsx
+++ b/src/components/Explore/DraggableCards.tsx
@@ -24,7 +24,7 @@ import { clearAllMessagesAction } from "util/homemadeRedux/actions";
 const DEBUG = false;
 
 interface IDraggableCardsProps {
-  studentsToShow: IStudentSummary[];
+  studentsToShow: IStudentSummary[] | undefined;
 }
 
 const smoother = new SmoothVector();
@@ -161,8 +161,6 @@ const DraggableCards = ({ studentsToShow }: IDraggableCardsProps) => {
     DEBUG && console.log("updating");
     setMatrixEdges(getMatrixEdges(windowSizeInCards, matrixCenterXy));
   }, [...matrixCenterXy, windowSizeInCards]);
-
-  if (!studentsToShow) return null;
 
   return (
     <>

--- a/src/components/Explore/DraggableCards.tsx
+++ b/src/components/Explore/DraggableCards.tsx
@@ -82,12 +82,12 @@ const DraggableCards = ({ studentsToShow }: IDraggableCardsProps) => {
   const prevHeight = usePrevious(windowHeight);
 
   const [clearedDraggingTip, setClearedDraggingTip] = useState<number>(0);
-  const clearDraggineTipTwice = () => {
+  const clearDraggineTipTwice = useCallback(() => {
     if (clearedDraggingTip <= 2) {
       dispatch!(clearAllMessagesAction());
       setClearedDraggingTip((prev) => (prev += 1));
     }
-  };
+  }, [clearedDraggingTip]);
 
   const setSpringAndMatrixCenterXY = useCallback(
     (xy?: number[], immediate: boolean = false) => {
@@ -119,15 +119,17 @@ const DraggableCards = ({ studentsToShow }: IDraggableCardsProps) => {
 
   useEffect(setSpringAndMatrixCenterXY, [windowSize]);
 
-  const scrollDivRef = useRef<HTMLDivElement>(null);
-  const onWheelHandler = (e: React.WheelEvent<HTMLDivElement>) => {
-    if (navigatorPlatform?.isMac) {
-      setSpringAndMatrixCenterXY(
-        [position.x.get() - e.deltaX, position.y.get() - e.deltaY],
-        true
-      );
-    }
-  };
+  const onWheelHandler = useCallback(
+    (e: React.WheelEvent<HTMLDivElement>) => {
+      if (navigatorPlatform?.isMac) {
+        setSpringAndMatrixCenterXY(
+          [position.x.get() - e.deltaX, position.y.get() - e.deltaY],
+          true
+        );
+      }
+    },
+    [navigatorPlatform]
+  );
 
   const bindDrag = useDrag(
     ({ down, movement: xy, velocity, direction }) => {
@@ -164,12 +166,7 @@ const DraggableCards = ({ studentsToShow }: IDraggableCardsProps) => {
 
   return (
     <>
-      <div
-        {...bindDrag()}
-        ref={scrollDivRef}
-        onWheel={onWheelHandler}
-        id="projects-canvas"
-      >
+      <div {...bindDrag()} onWheel={onWheelHandler} id="projects-canvas">
         <animated.div style={{ ...position }}>
           <CardsMatrix
             {...{

--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -114,8 +114,6 @@ const Explore = (props: IHomeProps) => {
     }
   }, [students]);
 
-  if (!filteredStudents) return <h2>loading...</h2>;
-
   return (
     <Container fluid>
       <div className="row">

--- a/src/components/Footer/Search.tsx
+++ b/src/components/Footer/Search.tsx
@@ -8,7 +8,7 @@ import { CloseBlack } from "images/Svg";
 interface SearchProps {
   text: string;
   textChanged: (search: string) => void;
-  searchResults: IStudentSummary[];
+  searchResults: IStudentSummary[] | undefined;
 }
 
 const SearchMain = ({ text, textChanged, searchResults }: SearchProps) => {
@@ -38,18 +38,19 @@ const SearchMain = ({ text, textChanged, searchResults }: SearchProps) => {
         </Nav.Item>
       </FooterLeft>
       <ScrollableFooterRight>
-        {searchResults.map((student) => (
-          <Nav.Item key={student.student_id}>
-            <Link
-              to={`/students/${student.student_id}`}
-              onDragStart={(e) => {
-                e.preventDefault();
-              }}
-            >
-              {student.student_name}
-            </Link>
-          </Nav.Item>
-        ))}
+        {searchResults &&
+          searchResults.map((student) => (
+            <Nav.Item key={student.student_id}>
+              <Link
+                to={`/students/${student.student_id}`}
+                onDragStart={(e) => {
+                  e.preventDefault();
+                }}
+              >
+                {student.student_name}
+              </Link>
+            </Nav.Item>
+          ))}
       </ScrollableFooterRight>
     </>
   );

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -32,7 +32,7 @@ interface FooterProps {
   advisors?: StringDict;
   searchText: string;
   searchTextChanged: (searchText: string) => void;
-  filteredStudents: IStudentSummary[];
+  filteredStudents: IStudentSummary[] | undefined;
   show: boolean;
 }
 

--- a/src/components/Shared/StudentCard.tsx
+++ b/src/components/Shared/StudentCard.tsx
@@ -86,7 +86,7 @@ export const CardOuter = ({
 );
 
 interface IStudentCardProps {
-  student: IStudentSummary;
+  student: IStudentSummary | undefined;
   cardSize: ICardSize;
 }
 
@@ -116,6 +116,8 @@ export const StudentCard = ({ student, cardSize }: IStudentCardProps) => {
     [clickStartXy]
   );
 
+  if (!student) return null;
+
   return (
     <CardOuter width={cardSize.width} height={cardSize.height}>
       <Link
@@ -132,7 +134,13 @@ export const StudentCard = ({ student, cardSize }: IStudentCardProps) => {
 
 const formatTag = (tagName: string) => he.decode(tagName.toUpperCase());
 
-export const CardContent = ({ student, cardSize }: IStudentCardProps) => {
+export const CardContent = ({
+  student,
+  cardSize,
+}: {
+  student: IStudentSummary;
+  cardSize: ICardSize;
+}) => {
   const tags = useMemo(
     () =>
       student.topics.map(({ name }, index) =>

--- a/src/components/Shared/StudentCard.tsx
+++ b/src/components/Shared/StudentCard.tsx
@@ -86,27 +86,21 @@ interface IStudentCardProps {
 
 export const StudentCard = React.memo(
   ({ student, cardSize }: IStudentCardProps) => {
-    const linkRef = useRef<null | HTMLAnchorElement | any>(null);
     const [isDragging, setDragging] = useState<boolean>(false);
     const onClick = useCallback(
-      () => (e: React.FormEvent<HTMLAnchorElement>): void => {
+      (e: React.FormEvent<HTMLAnchorElement>): void => {
         if (isDragging) e.preventDefault();
       },
       [isDragging]
     );
 
     const [clickStartXy, setClickStartXy] = useState([0, 0]);
-    const onMouseDown = useCallback(
-      () => (e: React.MouseEvent) => {
-        if (!linkRef.current) return;
-        setClickStartXy([e.clientX, e.clientY]);
-      },
-      []
-    );
+    const onMouseDown = useCallback((e: React.MouseEvent) => {
+      setClickStartXy([e.clientX, e.clientY]);
+    }, []);
 
     const onMouseUp = useCallback(
-      () => (e: React.MouseEvent) => {
-        if (!linkRef.current) return;
+      (e: React.MouseEvent) => {
         const dist = Math.hypot(
           e.clientX - clickStartXy[0],
           e.clientY - clickStartXy[1]
@@ -121,7 +115,6 @@ export const StudentCard = React.memo(
       <CardOuter width={cardSize.width} height={cardSize.height}>
         <Link
           to={`/students/${student.student_id}`}
-          ref={linkRef}
           onMouseDown={onMouseDown}
           onMouseUp={onMouseUp}
           onClick={onClick}

--- a/src/components/Shared/StudentCard.tsx
+++ b/src/components/Shared/StudentCard.tsx
@@ -84,76 +84,72 @@ interface IStudentCardProps {
   cardSize: ICardSize;
 }
 
-export const StudentCard = React.memo(
-  ({ student, cardSize }: IStudentCardProps) => {
-    const [isDragging, setDragging] = useState<boolean>(false);
-    const onClick = useCallback(
-      (e: React.FormEvent<HTMLAnchorElement>): void => {
-        if (isDragging) e.preventDefault();
-      },
-      [isDragging]
-    );
+export const StudentCard = ({ student, cardSize }: IStudentCardProps) => {
+  const [isDragging, setDragging] = useState<boolean>(false);
+  const onClick = useCallback(
+    (e: React.FormEvent<HTMLAnchorElement>): void => {
+      if (isDragging) e.preventDefault();
+    },
+    [isDragging]
+  );
 
-    const [clickStartXy, setClickStartXy] = useState([0, 0]);
-    const onMouseDown = useCallback((e: React.MouseEvent) => {
-      setClickStartXy([e.clientX, e.clientY]);
-    }, []);
+  const [clickStartXy, setClickStartXy] = useState([0, 0]);
+  const onMouseDown = useCallback((e: React.MouseEvent) => {
+    setClickStartXy([e.clientX, e.clientY]);
+  }, []);
 
-    const onMouseUp = useCallback(
-      (e: React.MouseEvent) => {
-        const dist = Math.hypot(
-          e.clientX - clickStartXy[0],
-          e.clientY - clickStartXy[1]
-        );
-        if (dist > 10) setDragging(true);
-        else setDragging(false);
-      },
-      [clickStartXy]
-    );
+  const onMouseUp = useCallback(
+    (e: React.MouseEvent) => {
+      const dist = Math.hypot(
+        e.clientX - clickStartXy[0],
+        e.clientY - clickStartXy[1]
+      );
+      if (dist > 10) setDragging(true);
+      else setDragging(false);
+    },
+    [clickStartXy]
+  );
 
-    return (
-      <CardOuter width={cardSize.width} height={cardSize.height}>
-        <Link
-          to={`/students/${student.student_id}`}
-          onMouseDown={onMouseDown}
-          onMouseUp={onMouseUp}
-          onClick={onClick}
-        >
-          <CardContent {...{ student, cardSize }} />
-        </Link>
-      </CardOuter>
-    );
-  }
-);
+  return (
+    <CardOuter width={cardSize.width} height={cardSize.height}>
+      <Link
+        to={`/students/${student.student_id}`}
+        onMouseDown={onMouseDown}
+        onMouseUp={onMouseUp}
+        onClick={onClick}
+      >
+        <CardContent {...{ student, cardSize }} />
+      </Link>
+    </CardOuter>
+  );
+};
 
 const formatTag = (tagName: string) => he.decode(tagName.toUpperCase());
 
-export const CardContent = React.memo(
-  ({ student, cardSize }: IStudentCardProps) => (
-    <>
-      <div className="card-bg-frame">
-        <div
-          className="card-bg"
-          style={{
-            backgroundImage: `url(${
-              student.portfolio_thumbnail && student.portfolio_thumbnail.src
-            })`,
-            width: cardSize.width,
-          }}
-        />
-      </div>
-      <div className="card-info mt-2" style={{ height: cardSize.infoHeight }}>
-        <h3>{he.decode(student.project_title)}</h3>
-        <h4>{student.student_name}</h4>
-        <p>
-          {student.topics.map((tag, index) =>
-            index === student.topics.length - 1
-              ? formatTag(tag.name)
-              : formatTag(tag.name) + ", "
-          )}
-        </p>
-      </div>
-    </>
-  )
+export const CardContent = ({ student, cardSize }: IStudentCardProps) => (
+  <>
+    <div className="card-bg-frame">
+      <div
+        className="card-bg"
+        style={{
+          backgroundImage: `url(${
+            student.portfolio_thumbnail && student.portfolio_thumbnail.src
+          })`,
+          width: cardSize.width,
+        }}
+      />
+    </div>
+    <div className="card-info mt-2" style={{ height: cardSize.infoHeight }}>
+      <h3>{he.decode(student.project_title)}</h3>
+      <h4>{student.student_name}</h4>
+      <p>
+        {student.topics.map((tag, index) =>
+          index === student.topics.length - 1
+            ? formatTag(tag.name)
+            : formatTag(tag.name) + ", "
+        )}
+      </p>
+    </div>
+  </>
 );
 export default StudentCard;

--- a/src/components/Shared/StudentCard.tsx
+++ b/src/components/Shared/StudentCard.tsx
@@ -1,4 +1,10 @@
-import React, { useRef, useState, useContext, useCallback } from "react";
+import React, {
+  useRef,
+  useState,
+  useContext,
+  useCallback,
+  useMemo,
+} from "react";
 import { IStudentSummary, ICardSize } from "types";
 import { Link } from "react-router-dom";
 import {
@@ -126,30 +132,41 @@ export const StudentCard = ({ student, cardSize }: IStudentCardProps) => {
 
 const formatTag = (tagName: string) => he.decode(tagName.toUpperCase());
 
-export const CardContent = ({ student, cardSize }: IStudentCardProps) => (
-  <>
-    <div className="card-bg-frame">
-      <div
-        className="card-bg"
-        style={{
-          backgroundImage: `url(${
-            student.portfolio_thumbnail && student.portfolio_thumbnail.src
-          })`,
-          width: cardSize.width,
-        }}
-      />
-    </div>
-    <div className="card-info mt-2" style={{ height: cardSize.infoHeight }}>
-      <h3>{he.decode(student.project_title)}</h3>
-      <h4>{student.student_name}</h4>
-      <p>
-        {student.topics.map((tag, index) =>
-          index === student.topics.length - 1
-            ? formatTag(tag.name)
-            : formatTag(tag.name) + ", "
-        )}
-      </p>
-    </div>
-  </>
-);
+export const CardContent = ({ student, cardSize }: IStudentCardProps) => {
+  const tags = useMemo(
+    () =>
+      student.topics.map(({ name }, index) =>
+        index === student.topics.length - 1
+          ? formatTag(name)
+          : formatTag(name) + ", "
+      ),
+    [student.topics]
+  );
+
+  return (
+    <>
+      {" "}
+      <div className="card-bg-frame">
+        <div
+          className="card-bg"
+          style={{
+            backgroundImage: `url(${
+              student.portfolio_thumbnail && student.portfolio_thumbnail.src
+            })`,
+            width: cardSize.width,
+          }}
+        />
+      </div>
+      <div className="card-info mt-2" style={{ height: cardSize.infoHeight }}>
+        <h3>
+          {useMemo(() => he.decode(student.project_title), [
+            student.project_title,
+          ])}
+        </h3>
+        <h4>{student.student_name}</h4>
+        <p>{tags}</p>
+      </div>
+    </>
+  );
+};
 export default StudentCard;

--- a/src/components/Shared/StudentCard.tsx
+++ b/src/components/Shared/StudentCard.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useContext } from "react";
+import React, { useRef, useState, useContext, useCallback } from "react";
 import { IStudentSummary, ICardSize } from "types";
 import { Link } from "react-router-dom";
 import {
@@ -88,23 +88,35 @@ export const StudentCard = React.memo(
   ({ student, cardSize }: IStudentCardProps) => {
     const linkRef = useRef<null | HTMLAnchorElement | any>(null);
     const [isDragging, setDragging] = useState<boolean>(false);
-    const onClick = (e: React.FormEvent<HTMLAnchorElement>): void => {
-      if (isDragging) e.preventDefault();
-    };
-    let clickStartXy = [0, 0];
-    const onMouseDown = (e: React.MouseEvent) => {
-      if (!linkRef.current) return;
-      clickStartXy = [e.clientX, e.clientY];
-    };
-    const onMouseUp = (e: React.MouseEvent) => {
-      if (!linkRef.current) return;
-      const dist = Math.hypot(
-        e.clientX - clickStartXy[0],
-        e.clientY - clickStartXy[1]
-      );
-      if (dist > 10) setDragging(true);
-      else setDragging(false);
-    };
+    const onClick = useCallback(
+      () => (e: React.FormEvent<HTMLAnchorElement>): void => {
+        if (isDragging) e.preventDefault();
+      },
+      [isDragging]
+    );
+
+    const [clickStartXy, setClickStartXy] = useState([0, 0]);
+    const onMouseDown = useCallback(
+      () => (e: React.MouseEvent) => {
+        if (!linkRef.current) return;
+        setClickStartXy([e.clientX, e.clientY]);
+      },
+      []
+    );
+
+    const onMouseUp = useCallback(
+      () => (e: React.MouseEvent) => {
+        if (!linkRef.current) return;
+        const dist = Math.hypot(
+          e.clientX - clickStartXy[0],
+          e.clientY - clickStartXy[1]
+        );
+        if (dist > 10) setDragging(true);
+        else setDragging(false);
+      },
+      [clickStartXy]
+    );
+
     return (
       <CardOuter width={cardSize.width} height={cardSize.height}>
         <Link

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,7 +90,6 @@ export interface VideoScheduleRowContents {
 export interface CardToShow {
   matrixX: number;
   matrixY: number;
-  student: IStudentSummary;
   offset: [number, number];
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,9 +88,10 @@ export interface VideoScheduleRowContents {
 }
 
 export interface CardToShow {
-  student: IStudentSummary;
   matrixX: number;
   matrixY: number;
+  student: IStudentSummary;
+  offset: [number, number];
 }
 
 export declare type IStudentFilter = (student: IStudentSummary) => boolean;


### PR DESCRIPTION
A bunch of optimizations to explore to make it load faster.  Behavior is not changed; just the performance:

* In `CardMatrix` only recalculating grid when it changes.  Calculate students to show when those change.  Also memoizing the offset calculation with card matrix.  A lot less is calculated now on each change.
* In `StudentCard` memoizing the callback functions so that they are not re-built on every render.
* Rendering components of explore even when students are not available yet, so that they are rendered on page load and not when drawn every time.