### PR TITLE
Remove bouncing on mobile

### DIFF
--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -126,7 +126,6 @@ const Explore = (props: IHomeProps) => {
         searchTextChanged={setSearchText}
         filteredStudents={filteredStudents}
       />
-      )}
     </Container>
   );
 };

--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useContext, useEffect, useMemo } from "react";
+import { Context } from "util/contexts";
 // import StudentCards from "./StudentCards";
 import { IStudentSummary, StringDict, ISearch } from "types";
 import DraggableCards from "./DraggableCards";
@@ -17,6 +18,19 @@ const generateTitle = (tag: string | null, advisor: string | null): string => {
   }
 
   return opener;
+};
+
+const setHtmlOverscrollBehaviorX = (value: string): void => {
+  document
+    .getElementsByTagName("html")[0]
+    .setAttribute("style", `overscroll-behavior-x:${value}`);
+};
+
+const setBodyOverfolowOnMobile = (value: string, isMobile: boolean): void => {
+  isMobile &&
+    document
+      .getElementsByTagName("body")[0]
+      .setAttribute("style", `overflow:${value}`);
 };
 
 interface IHomeProps {
@@ -39,6 +53,7 @@ const noFilter = (student: IStudentSummary) => true;
 
 const Explore = (props: IHomeProps) => {
   const { isExploring } = props;
+  const { navigatorPlatform } = useContext(Context);
 
   const students = useMemo(() => {
     if (!props.students) {
@@ -113,6 +128,17 @@ const Explore = (props: IHomeProps) => {
       setFilterOptions(queries.getTagsAndAdvisors(students));
     }
   }, [students]);
+
+  //remove HtmlOverscrollBehaviorX and elastic scrolling
+  useEffect(() => {
+    const { isMobile } = navigatorPlatform!;
+    setHtmlOverscrollBehaviorX("none");
+    setBodyOverfolowOnMobile("hidden", isMobile);
+    return () => {
+      setHtmlOverscrollBehaviorX("auto");
+      setBodyOverfolowOnMobile("auto", isMobile);
+    };
+  }, [navigatorPlatform]);
 
   return (
     <Container fluid>

--- a/src/components/Shared/BigHeader.tsx
+++ b/src/components/Shared/BigHeader.tsx
@@ -16,19 +16,6 @@ export const getHeaderHeight = (windowWidth: number): number => {
   }
 };
 
-const setHtmlOverscrollBehaviorX = (value: string): void => {
-  document
-    .getElementsByTagName("html")[0]
-    .setAttribute("style", `overscroll-behavior-x:${value}`);
-};
-
-const setBodyOverfolowOnMobile = (value: string, isMobile: boolean): void => {
-  isMobile &&
-    document
-      .getElementsByTagName("body")[0]
-      .setAttribute("style", `overflow:${value}`);
-};
-
 export const HEADER_HEIGHT_IN_VH = getHeaderHeight(window.innerWidth);
 const BG_SCROLL_SPEED = 0.066;
 const BG_ROWS = 2;
@@ -73,14 +60,6 @@ const HeaderSpring = ({
   }, [setSpring, collapse, addMessage, isAtHomePage, navigatorPlatform]);
 
   useEffect(collapseHeaderAndShowMessage, [collapse]);
-
-  useEffect(() => {
-    setHtmlOverscrollBehaviorX(isAtHomePage ? "none" : "auto");
-    setBodyOverfolowOnMobile(
-      isAtHomePage ? "hidden" : "auto",
-      navigatorPlatform!.isMobile
-    );
-  }, [isAtHomePage, navigatorPlatform]);
 
   useEffect(() => {
     //@ts-ignore

--- a/src/components/Shared/BigHeader.tsx
+++ b/src/components/Shared/BigHeader.tsx
@@ -22,6 +22,13 @@ const setHtmlOverscrollBehaviorX = (value: string): void => {
     .setAttribute("style", `overscroll-behavior-x:${value}`);
 };
 
+const setBodyOverfolowOnMobile = (value: string, isMobile: boolean): void => {
+  isMobile &&
+    document
+      .getElementsByTagName("body")[0]
+      .setAttribute("style", `overflow:${value}`);
+};
+
 export const HEADER_HEIGHT_IN_VH = getHeaderHeight(window.innerWidth);
 const BG_SCROLL_SPEED = 0.066;
 const BG_ROWS = 2;
@@ -69,7 +76,11 @@ const HeaderSpring = ({
 
   useEffect(() => {
     setHtmlOverscrollBehaviorX(isAtHomePage ? "none" : "auto");
-  }, [isAtHomePage]);
+    setBodyOverfolowOnMobile(
+      isAtHomePage ? "hidden" : "auto",
+      navigatorPlatform!.isMobile
+    );
+  }, [isAtHomePage, navigatorPlatform]);
 
   useEffect(() => {
     //@ts-ignore


### PR DESCRIPTION
On mobile, when dragging, it feels unpleasant because of the elastic bouncing feature of Safari.

The only way to get rid of it is set `overflow` of body to `hidden`. But we have to do it only on the explore page, for it will stop scrolling features on other pages.

I added this feature on `BigHeader` because I already have something similar in that component. However, I don't think it's a good place to toggle this feature. Please let me know if you have a suggestion.

Feels good creating PR again! 

